### PR TITLE
Add dockerfile to handle dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM rocker/verse:3.6.3
+
+RUN apt-get update \
+    && apt upgrade -y
+
+RUN Rscript -e 'update.packages()'
+RUN Rscript -e 'install.packages("sampleSelection", version = "1.2-12")'
+RUN Rscript -e 'install.packages("latex2exp", version = "0.5.0")'


### PR DESCRIPTION
A proposal to manage R packages that are needed for running the script. The user would be given the possibility to create a Docker image that would embed the installation of the packages that are needed to properly reproduce the results. Therefore you may discard lines [13-15](https://github.com/InseeFrLab/NRC-Heck-model/blob/bb7f1165c98b03b167ef12a8be56ec227707d787/NRC-Heck-model.R#L13) of the script. 